### PR TITLE
fix(FEC-8311):  Live with DVR - when seeking back (more then dvrThreshold) the playbackType is not "dvr"

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,7 @@
   serviceUrl: '//analytics.kaltura.com/api_v3/index.php',
   viewEventCountdown: 10,
   resetSessionCountdown: 30,
-  dvrThreshold: 120000
+  dvrThreshold: 120
 }
 ```
 
@@ -63,9 +63,9 @@
 >
 > ##### Type: `number`
 >
-> ##### Default: `120000`
+> ##### Default: `120`
 >
-> ##### Description: Threshold in milliseconds from the live edge.
+> ##### Description: Threshold in seconds from the live edge.
 >
 > When player's playback position from the live edge <= then dvrThreshold, Kava will set playbackType to dvr. Otherwise it will be live.
 

--- a/src/kava.js
+++ b/src/kava.js
@@ -36,7 +36,7 @@ export default class Kava extends BasePlugin {
     serviceUrl: '//analytics.kaltura.com/api_v3/index.php',
     viewEventCountdown: 10,
     resetSessionCountdown: 30,
-    dvrThreshold: 120000,
+    dvrThreshold: 120,
     playbackContext: '',
     applicationVersion: ''
   };


### PR DESCRIPTION
### Description of the Changes

Change dvrThreshold units to seconds.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
