### PR TITLE
fix(FEC-8414): referrer should not be base64 encoded

### DIFF
--- a/src/kava.js
+++ b/src/kava.js
@@ -360,7 +360,7 @@ class Kava extends BasePlugin {
     this._model.getClientTag = () => 'html5:v' + this.config.playerVersion;
     this._model.getKS = () => this.config.ks;
     this._model.getUIConfId = () => this.config.uiConfId;
-    this._model.getReferrer = () => btoa(this.config.referrer);
+    this._model.getReferrer = () => this.config.referrer;
     this._model.getCustomVar1 = () => this.config.customVar1;
     this._model.getCustomVar2 = () => this.config.customVar2;
     this._model.getCustomVar3 = () => this.config.customVar3;

--- a/test/src/kava.spec.js
+++ b/test/src/kava.spec.js
@@ -139,7 +139,7 @@ describe('KavaPlugin', function() {
       params.sessionId.should.equal(config.session.id);
       params.eventIndex.should.equal(1);
       params.ks.should.equal(config.session.ks);
-      params.referrer.should.equal(btoa(config.plugins.kava.referrer));
+      params.referrer.should.equal(config.plugins.kava.referrer);
       params.deliveryType.should.equal('url');
       params.playbackType.should.equal('vod');
       (!!params.sessionStartTime).should.be.false;


### PR DESCRIPTION
### Description of the Changes

Change referrer string to only be URI encoded and not base64 encoded

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
