### PR TITLE
fix: use FIRST_PLAYING event instead of PLAYBACK_STARTED

### DIFF
--- a/src/kava.js
+++ b/src/kava.js
@@ -167,7 +167,7 @@ class Kava extends BasePlugin {
     this.eventManager.listen(this.player, this.player.Event.FIRST_PLAY, () => this._onFirstPlay());
     this.eventManager.listen(this.player, this.player.Event.TRACKS_CHANGED, () => this._setInitialTracks());
     this.eventManager.listen(this.player, this.player.Event.PLAYING, () => this._onPlaying());
-    this.eventManager.listen(this.player, this.player.Event.PLAYBACK_STARTED, () => (this._isPlaying = true));
+    this.eventManager.listen(this.player, this.player.Event.FIRST_PLAYING, () => (this._isPlaying = true));
     this.eventManager.listen(this.player, this.player.Event.SEEKING, () => this._onSeeking());
     this.eventManager.listen(this.player, this.player.Event.PAUSE, () => this._onPause());
     this.eventManager.listen(this.player, this.player.Event.ENDED, () => this._onEnded());


### PR DESCRIPTION
since https://github.com/kaltura/playkit-js/pull/288

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
