### PR TITLE
fix(FEC-8606): "Play 100%" event is not sent on IE11 Win7

### DIFF
--- a/src/kava.js
+++ b/src/kava.js
@@ -334,7 +334,7 @@ class Kava extends BasePlugin {
         this._timePercentEvent.PLAY_REACHED_75 = true;
         this._sendAnalytics(KavaEventModel.PLAY_REACHED_75_PERCENT);
       }
-      if (!this._timePercentEvent.PLAY_REACHED_100 && percent === 1) {
+      if (!this._timePercentEvent.PLAY_REACHED_100 && percent >= 1) {
         this._timePercentEvent.PLAY_REACHED_100 = true;
         this._sendAnalytics(KavaEventModel.PLAY_REACHED_100_PERCENT);
       }

--- a/src/kava.js
+++ b/src/kava.js
@@ -318,6 +318,7 @@ class Kava extends BasePlugin {
     this._model.updateModel({bufferTime: 0});
   }
 
+  /**/
   _onTimeUpdate(): void {
     if (!this.player.isLive()) {
       this._updatePlayTimeSumModel();

--- a/src/kava.js
+++ b/src/kava.js
@@ -318,7 +318,6 @@ class Kava extends BasePlugin {
     this._model.updateModel({bufferTime: 0});
   }
 
-  /**/
   _onTimeUpdate(): void {
     if (!this.player.isLive()) {
       this._updatePlayTimeSumModel();

--- a/src/kava.js
+++ b/src/kava.js
@@ -334,7 +334,7 @@ class Kava extends BasePlugin {
         this._timePercentEvent.PLAY_REACHED_75 = true;
         this._sendAnalytics(KavaEventModel.PLAY_REACHED_75_PERCENT);
       }
-      if (!this._timePercentEvent.PLAY_REACHED_100 && percent >= 1) {
+      if (!this._timePercentEvent.PLAY_REACHED_100 && percent === 1) {
         this._timePercentEvent.PLAY_REACHED_100 = true;
         this._sendAnalytics(KavaEventModel.PLAY_REACHED_100_PERCENT);
       }

--- a/src/kava.js
+++ b/src/kava.js
@@ -321,7 +321,7 @@ class Kava extends BasePlugin {
   _onTimeUpdate(): void {
     if (!this.player.isLive()) {
       this._updatePlayTimeSumModel();
-      const percent = this.player.currentTime / this.player.duration;
+      const percent = parseFloat((this.player.currentTime / this.player.duration).toFixed(2));
       if (!this._timePercentEvent.PLAY_REACHED_25 && percent >= 0.25) {
         this._timePercentEvent.PLAY_REACHED_25 = true;
         this._sendAnalytics(KavaEventModel.PLAY_REACHED_25_PERCENT);


### PR DESCRIPTION
### Description of the Changes

`const percent = this.player.currentTime / this.player.duration`, returened a number above 1 on IE 11, therefore, never entred, the `if (!this._timePercentEvent.PLAY_REACHED_100 && percent === 1)` condition.

The fix: 
1. Limiting the float to have only 2 decimals at the end using the `toFixed` function.
2. Parsing the calculation using `parseFloat` function.

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
