### PR TITLE
feat(FEC-8803): add 'canPlay' param to the 'play' event

### DIFF
--- a/src/kava-event-model.js
+++ b/src/kava-event-model.js
@@ -52,7 +52,8 @@ export const KavaEventModel: {[event: string]: KavaEvent} = {
       bufferTime: model.getBufferTime(),
       bufferTimeSum: model.getBufferTimeSum(),
       actualBitrate: model.getActualBitrate(),
-      joinTime: model.getJoinTime()
+      joinTime: model.getJoinTime(),
+      canPlay: model.getCanPlayTime()
     })
   },
   /**

--- a/src/kava-model.js
+++ b/src/kava-model.js
@@ -17,6 +17,7 @@ class KavaModel {
   caption: string;
   errorCode: number;
   joinTime: number;
+  canPlayTime: number;
   targetPosition: number;
   getActualBitrate: Function;
   getAverageBitrate: Function;
@@ -37,6 +38,7 @@ class KavaModel {
   getPlaybackType: Function;
   getPlaybackContext: Function;
   getApplicationVersion: Function;
+  getCanPlayTime: Function;
 
   constructor(model?: Object) {
     if (model) {
@@ -52,6 +54,10 @@ class KavaModel {
    */
   getPlayTimeSum(): number {
     return this.playTimeSum;
+  }
+
+  getCanPlayTime(): number {
+    return this.canPlayTime;
   }
 
   /**

--- a/src/kava.js
+++ b/src/kava.js
@@ -227,10 +227,10 @@ class Kava extends BasePlugin {
     this.eventManager.listen(this._timer, KavaTimer.Event.RESET, () => this._resetSession());
     this.eventManager.listen(this.player, this.player.Event.SOURCE_SELECTED, () => this._onSourceSelected());
     this.eventManager.listen(this.player, this.player.Event.ERROR, event => this._onError(event));
-    this.eventManager.listen(this.player, this.player.Event.PLAY_REQUESTED, () => this._onPlayRequested());
+    this.eventManager.listen(this.player, this.player.Event.PLAYBACK_START, () => this._onPlaybackStart());
     this.eventManager.listen(this.player, this.player.Event.TRACKS_CHANGED, () => this._setInitialTracks());
     this.eventManager.listen(this.player, this.player.Event.PLAYING, () => this._onPlaying());
-    this.eventManager.listen(this.player, this.player.Event.FIRST_PLAYING, () => (this._isPlaying = true));
+    this.eventManager.listen(this.player, this.player.Event.FIRST_PLAYING, () => this._onFirstPlaying());
     this.eventManager.listen(this.player, this.player.Event.SEEKING, () => this._onSeeking());
     this.eventManager.listen(this.player, this.player.Event.PAUSE, () => this._onPause());
     this.eventManager.listen(this.player, this.player.Event.ENDED, () => this._onEnded());
@@ -240,7 +240,15 @@ class Kava extends BasePlugin {
     this.eventManager.listen(this.player, this.player.Event.TEXT_TRACK_CHANGED, event => this._onTextTrackChanged(event));
     this.eventManager.listen(this.player, this.player.Event.PLAYER_STATE_CHANGED, event => this._onPlayerStateChanged(event));
     this.eventManager.listen(this.player, this.player.Event.CAN_PLAY, () => this._onCanPlay());
-    this.eventManager.listen(this.player, this.player.Event.LOAD_START, () => (this._loadStartTime = Date.now()));
+    this.eventManager.listen(this.player, this.player.Event.LOAD_START, () => this._onLoadStart());
+  }
+
+  _onFirstPlaying(): void {
+    this._isPlaying = true;
+  }
+
+  _onLoadStart(): void {
+    this._loadStartTime = Date.now();
   }
 
   _getRates(): Array<number> {
@@ -300,7 +308,7 @@ class Kava extends BasePlugin {
     });
   }
 
-  _onPlayRequested(): void {
+  _onPlaybackStart(): void {
     if (!this._firstPlayRequestTime) {
       this._firstPlayRequestTime = Date.now();
       this._sendAnalytics(KavaEventModel.PLAY_REQUEST);

--- a/test/src/kava-event-model.spec.js
+++ b/test/src/kava-event-model.spec.js
@@ -1,6 +1,10 @@
 import {KavaEventModel} from '../../src/kava-event-model';
 
 class FakeModel {
+  getCanPlayTime() {
+    return 10;
+  }
+
   getPlayTimeSum() {
     return 10;
   }
@@ -78,7 +82,8 @@ describe('KavaEventModel', () => {
       bufferTime: fakeModel.getBufferTime(),
       bufferTimeSum: fakeModel.getBufferTimeSum(),
       actualBitrate: fakeModel.getActualBitrate(),
-      joinTime: fakeModel.getJoinTime()
+      joinTime: fakeModel.getJoinTime(),
+      canPlay: fakeModel.getCanPlayTime()
     });
   });
 


### PR DESCRIPTION
add `canPlay` param to the `play` event kava sends.
Also, changed the way we measure joinTime.
Untill now it was measured from the `play` event sent from the video element until the `playing` event.


### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
