### PR TITLE
revert: new joinTime calculation (#31)

### DIFF
--- a/src/kava.js
+++ b/src/kava.js
@@ -227,7 +227,7 @@ class Kava extends BasePlugin {
     this.eventManager.listen(this._timer, KavaTimer.Event.RESET, () => this._resetSession());
     this.eventManager.listen(this.player, this.player.Event.SOURCE_SELECTED, () => this._onSourceSelected());
     this.eventManager.listen(this.player, this.player.Event.ERROR, event => this._onError(event));
-    this.eventManager.listen(this.player, this.player.Event.PLAYBACK_START, () => this._onPlaybackStart());
+    this.eventManager.listen(this.player, this.player.Event.FIRST_PLAY, () => this._onFirstPlay());
     this.eventManager.listen(this.player, this.player.Event.TRACKS_CHANGED, () => this._setInitialTracks());
     this.eventManager.listen(this.player, this.player.Event.PLAYING, () => this._onPlaying());
     this.eventManager.listen(this.player, this.player.Event.FIRST_PLAYING, () => this._onFirstPlaying());
@@ -308,7 +308,7 @@ class Kava extends BasePlugin {
     });
   }
 
-  _onPlaybackStart(): void {
+  _onFirstPlay(): void {
     this._firstPlayRequestTime = Date.now();
     this._sendAnalytics(KavaEventModel.PLAY_REQUEST);
   }

--- a/src/kava.js
+++ b/src/kava.js
@@ -309,10 +309,8 @@ class Kava extends BasePlugin {
   }
 
   _onPlaybackStart(): void {
-    if (!this._firstPlayRequestTime) {
-      this._firstPlayRequestTime = Date.now();
-      this._sendAnalytics(KavaEventModel.PLAY_REQUEST);
-    }
+    this._firstPlayRequestTime = Date.now();
+    this._sendAnalytics(KavaEventModel.PLAY_REQUEST);
   }
 
   _onSourceSelected(): void {


### PR DESCRIPTION
### Description of the Changes
Reverts the new join time calculation which was part of
https://github.com/kaltura/playkit-js-kava/pull/31

Join Time calculation needs to be defined in various edge cases (like ads). This requires handling ads event in kava which will be done in the future.


### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
