### PR TITLE
feat(FEC-9071): add errorDetails field to kava error reporting

### DIFF
--- a/src/kava-event-model.js
+++ b/src/kava-event-model.js
@@ -205,7 +205,7 @@ export const KavaEventModel: {[event: string]: KavaEvent} = {
     index: 98,
     getEventModel: (model: KavaModel) => ({
       errorCode: model.getErrorCode(),
-      errorDetails: model.getErrorDetails() ? JSON.stringify(model.getErrorDetails()) : model.getErrorDetails()
+      errorDetails: model.getErrorDetails()
     })
   }
 };

--- a/src/kava-event-model.js
+++ b/src/kava-event-model.js
@@ -204,7 +204,8 @@ export const KavaEventModel: {[event: string]: KavaEvent} = {
     type: 'ERROR',
     index: 98,
     getEventModel: (model: KavaModel) => ({
-      errorCode: model.getErrorCode()
+      errorCode: model.getErrorCode(),
+      errorDetails: model.getErrorDetails() ? JSON.stringify(model.getErrorDetails()) : model.getErrorDetails()
     })
   }
 };

--- a/src/kava-model.js
+++ b/src/kava-model.js
@@ -133,12 +133,20 @@ class KavaModel {
 
   /**
    * Gets the error additional data.
-   * @returns {any} - The error data.
+   * @returns {string} - The stringifyed error data.
    * @memberof KavaModel
    * @instance
    */
-  getErrorDetails(): any {
-    return this.errorDetails;
+  getErrorDetails(): string {
+    let retVal: string = '';
+    if (this.errorDetails) {
+      try {
+        retVal = JSON.stringify(this.errorDetails);
+      } catch (e) {
+        // do nothing
+      }
+    }
+    return retVal;
   }
 
   /**

--- a/src/kava-model.js
+++ b/src/kava-model.js
@@ -16,6 +16,7 @@ class KavaModel {
   language: string;
   caption: string;
   errorCode: number;
+  errorDetails: any;
   joinTime: number;
   canPlayTime: number;
   targetPosition: number;
@@ -128,6 +129,16 @@ class KavaModel {
    */
   getErrorCode(): number {
     return this.errorCode;
+  }
+
+  /**
+   * Gets the error additional data.
+   * @returns {any} - The error data.
+   * @memberof KavaModel
+   * @instance
+   */
+  getErrorDetails(): any {
+    return this.errorDetails;
   }
 
   /**

--- a/src/kava.js
+++ b/src/kava.js
@@ -384,7 +384,7 @@ class Kava extends BasePlugin {
 
   _onError(event: FakeEvent): void {
     if (event.payload && event.payload.severity === PKError.Severity.CRITICAL) {
-      this._model.updateModel({errorCode: event.payload.code});
+      this._model.updateModel({errorCode: event.payload.code, errorDetails: event.payload.data});
       this._sendAnalytics(KavaEventModel.ERROR);
       this.reset();
     }

--- a/test/src/kava-event-model.spec.js
+++ b/test/src/kava-event-model.spec.js
@@ -37,6 +37,10 @@ class FakeModel {
     return 200;
   }
 
+  getErrorDetails() {
+    return {};
+  }
+
   getActualBitrate() {
     return 720;
   }
@@ -177,7 +181,8 @@ describe('KavaEventModel', () => {
     KavaEventModel.ERROR.type.should.equal('ERROR');
     KavaEventModel.ERROR.index.should.equal(98);
     KavaEventModel.ERROR.getEventModel(fakeModel).should.deep.equal({
-      errorCode: fakeModel.getErrorCode()
+      errorCode: fakeModel.getErrorCode(),
+      errorDetails: fakeModel.getErrorDetails()
     });
   });
 


### PR DESCRIPTION
### Description of the Changes

Added the "data" field sent from the player to a new field "errorDetails" in the kava get request.
Note that we are Stringifying the data field.
HLSJS sends a custom data field which is populated by us.
In Dash we send the native Shaka error array

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
