### PR TITLE
feat(FEC-9224): refactoring networkConnectionOverhead to use PerformanceObserver

### DIFF
--- a/src/kava.js
+++ b/src/kava.js
@@ -109,6 +109,10 @@ class Kava extends BasePlugin {
    */
   destroy(): void {
     this.eventManager.destroy();
+    this._reset();
+  }
+
+  _reset(): void {
     this._timer.destroy();
     this._rateHandler.destroy();
     this._performanceObserver.disconnect();
@@ -124,8 +128,6 @@ class Kava extends BasePlugin {
    */
   reset(): void {
     this.eventManager.removeAll();
-    this._rateHandler.destroy();
-    this._timer.destroy();
     this._resetFlags();
     this._addBindings();
     this._model.updateModel({
@@ -135,9 +137,7 @@ class Kava extends BasePlugin {
       playTimeSum: 0.0,
       sessionStartTime: null
     });
-    this._performanceObserver.disconnect();
-    this._performanceEntries = [];
-    this._pendingFragLoadedEvents = [];
+    this._reset();
   }
 
   /**

--- a/src/kava.js
+++ b/src/kava.js
@@ -281,7 +281,7 @@ class Kava extends BasePlugin {
     this._isPlaying = true;
     if (!this._fragLoadedFiredOnce && this._performaceObserver) {
       this._performaceObserver.disconnect();
-      this.logger.debug("This adapter / media doesn't fire fragLoaded");
+      this.logger.debug("This adapter / media doesn't fire fragLoaded - disconnect performance observer");
     }
   }
 

--- a/test/src/kava.spec.js
+++ b/test/src/kava.spec.js
@@ -520,35 +520,6 @@ describe('KavaPlugin', function() {
     });
 
     it('should send VIEW event with manifest download time, segment download time, bandwidth, networkConnectionOverhead', done => {
-      sandbox.stub(window.performance, 'getEntriesByType').callsFake(() => {
-        return [
-          {
-            name: 'http://www.somesite.com/movie.ts',
-            entryType: 'resource',
-            startTime: 118.6400000001413,
-            duration: 149.8900000001413,
-            initiatorType: 'script',
-            nextHopProtocol: 'http/1.1',
-            workerStart: 0,
-            redirectStart: 0,
-            redirectEnd: 0,
-            fetchStart: 118.6400000001413,
-            domainLookupStart: 20.2,
-            domainLookupEnd: 0,
-            connectStart: 0,
-            connectEnd: 120.5,
-            secureConnectionStart: 0,
-            requestStart: 0,
-            responseStart: 0,
-            responseEnd: 268.5300000002826,
-            transferSize: 0,
-            encodedBodySize: 0,
-            decodedBodySize: 0,
-            serverTiming: []
-          }
-        ];
-      });
-
       const DUMMY_MANIFEST_DOWNLOAD_TIME = 57;
       const FRAG1_DOWNLOAD_TIME = 100;
       const FRAG2_DOWNLOAD_TIME = 20;
@@ -568,6 +539,30 @@ describe('KavaPlugin', function() {
       });
       setupPlayer(config);
       kava = getKavaPlugin();
+      kava._performanceEntries.push({
+        name: 'http://www.somesite.com/movie.ts',
+        entryType: 'resource',
+        startTime: 118.6400000001413,
+        duration: 149.8900000001413,
+        initiatorType: 'script',
+        nextHopProtocol: 'http/1.1',
+        workerStart: 0,
+        redirectStart: 0,
+        redirectEnd: 0,
+        fetchStart: 118.6400000001413,
+        domainLookupStart: 20.2,
+        domainLookupEnd: 0,
+        connectStart: 0,
+        connectEnd: 120.5,
+        secureConnectionStart: 0,
+        requestStart: 0,
+        responseStart: 0,
+        responseEnd: 268.5300000002826,
+        transferSize: 0,
+        encodedBodySize: 0,
+        decodedBodySize: 0,
+        serverTiming: []
+      });
       player.play();
       player.dispatchEvent(
         new FakeEvent(CustomEventType.TIMED_METADATA, {


### PR DESCRIPTION
Refactored the networkConnectionOverhead to use PerformanceObserver due to buffer limitations of performance.getEntriesByType