### PR TITLE
fix(FEC-9258): Kaltura player tests fail when performanceObserver isn't define

### DIFF
--- a/src/kava.js
+++ b/src/kava.js
@@ -114,7 +114,9 @@ class Kava extends BasePlugin {
   _reset(): void {
     this._timer.destroy();
     this._rateHandler.destroy();
-    this._performanceObserver.disconnect();
+    if (this._performanceObserver && typeof this._performanceObserver.disconnet === 'function') {
+      this._performanceObserver.disconnect();
+    }
     this._performanceEntries = [];
     this._pendingFragLoadedUrls = [];
   }

--- a/src/kava.js
+++ b/src/kava.js
@@ -114,7 +114,7 @@ class Kava extends BasePlugin {
   _reset(): void {
     this._timer.destroy();
     this._rateHandler.destroy();
-    if (this._performanceObserver && typeof this._performanceObserver.disconnet === 'function') {
+    if (this._performanceObserver && typeof this._performanceObserver.disconnect === 'function') {
       this._performanceObserver.disconnect();
     }
     this._performanceEntries = [];

--- a/src/kava.js
+++ b/src/kava.js
@@ -114,7 +114,7 @@ class Kava extends BasePlugin {
   _reset(): void {
     this._timer.destroy();
     this._rateHandler.destroy();
-    if (this._performanceObserver && typeof this._performanceObserver.disconnect === 'function') {
+    if (this._performanceObserver) {
       this._performanceObserver.disconnect();
     }
     this._performanceEntries = [];


### PR DESCRIPTION
### Description of the Changes

Add check on kava for performanceObserver existence

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
