### PR TITLE
fix(FEC-9575): improve jointime calculation

### DIFF
--- a/src/kava.js
+++ b/src/kava.js
@@ -234,6 +234,8 @@ class Kava extends BasePlugin {
       PLAY_REACHED_75_PERCENT: false,
       PLAY_REACHED_100_PERCENT: false
     };
+    this._canPlayOccured = false;
+    this._isManualPreload = false;
   }
 
   _resetSession(): void {
@@ -468,11 +470,10 @@ class Kava extends BasePlugin {
       this._updateSoundModeInModel();
       this._timer.start();
       this._isFirstPlay = false;
+      const playStartTime =
+        this.player.config.playback.preload === 'auto' || this._isManualPreload ? this._firstPlayRequestTime : this._loadStartTime;
       this._model.updateModel({
-        joinTime:
-          this.player.config.playback.preload === 'auto' || this._isManualPreload
-            ? Kava._getTimeDifferenceInSeconds(this._firstPlayRequestTime)
-            : Kava._getTimeDifferenceInSeconds(this._loadStartTime)
+        joinTime: Kava._getTimeDifferenceInSeconds(playStartTime)
       });
       this._sendAnalytics(KavaEventModel.PLAY);
       this._onReport();

--- a/src/kava.js
+++ b/src/kava.js
@@ -286,7 +286,6 @@ class Kava extends BasePlugin {
     this.eventManager.listen(this.player, this.player.Event.MANIFEST_LOADED, event => this._onManifestLoaded(event));
     this.eventManager.listen(this.player, this.player.Event.TIMED_METADATA, event => this._onTimedMetadataLoaded(event));
     this.eventManager.listen(this.player, this.player.Event.TRACKS_CHANGED, () => this._setInitialTracks());
-    this.eventManager.listen(this.player, this.player.Event.PLAY, () => this._onPlay());
     this.eventManager.listen(this.player, this.player.Event.PLAYING, () => this._onPlaying());
     this.eventManager.listen(this.player, this.player.Event.FIRST_PLAYING, () => this._onFirstPlaying());
     this.eventManager.listen(this.player, this.player.Event.SEEKING, () => this._onSeeking());
@@ -464,12 +463,6 @@ class Kava extends BasePlugin {
     }
   }
 
-  _onPlay(): void {
-    if (this._canPlayOccured) {
-      this._isManualPreload = true;
-    }
-  }
-
   _onPlaying(): void {
     if (this._isFirstPlay) {
       this._updateSoundModeInModel();
@@ -502,6 +495,9 @@ class Kava extends BasePlugin {
   }
 
   _onFirstPlay(): void {
+    if (this._canPlayOccured) {
+      this._isManualPreload = true;
+    }
     this._firstPlayRequestTime = Date.now();
     this._sendAnalytics(KavaEventModel.PLAY_REQUEST);
   }

--- a/src/kava.js
+++ b/src/kava.js
@@ -470,10 +470,10 @@ class Kava extends BasePlugin {
       this._updateSoundModeInModel();
       this._timer.start();
       this._isFirstPlay = false;
-      const playStartTime =
+      const playRequestStartTime =
         this.player.config.playback.preload === 'auto' || this._isManualPreload ? this._firstPlayRequestTime : this._loadStartTime;
       this._model.updateModel({
-        joinTime: Kava._getTimeDifferenceInSeconds(playStartTime)
+        joinTime: Kava._getTimeDifferenceInSeconds(playRequestStartTime)
       });
       this._sendAnalytics(KavaEventModel.PLAY);
       this._onReport();


### PR DESCRIPTION
### Description of the Changes

if not preloaded then calc jointime as playing - startload
if preloaded (auto or manual) - calc as playing -  play 
auto preload is checked in config ('auto'). manual preloaded is true when canplay occured before the first play
Solves - FEC-9575
### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
