### PR TITLE
chore(FEC-9599): add units tests to jointime calc

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,12 +14,20 @@ const customLaunchers = {
   }
 };
 
+const launchers = {
+  Chrome_browser: {
+    base: 'Chrome',
+    flags: ['--no-sandbox', '--autoplay-policy=no-user-gesture-required']
+  }
+};
+
 module.exports = function(config) {
   let karmaConf = {
     logLevel: config.LOG_INFO,
-    browsers: ['Chrome'],
+    browsers: ['Chrome_browser'],
     browserDisconnectTimeout: 30000,
     browserNoActivityTimeout: 60000,
+    customLaunchers: launchers,
     concurrency: 1,
     singleRun: true,
     colors: true,

--- a/test/src/kava.spec.js
+++ b/test/src/kava.spec.js
@@ -95,6 +95,9 @@ describe('KavaPlugin', function() {
           }
         ]
       },
+      playback: {
+        preload: 'none'
+      },
       plugins: {
         kava: {
           referrer: 'referrer',
@@ -239,6 +242,109 @@ describe('KavaPlugin', function() {
       setupPlayer(config);
       kava = getKavaPlugin();
       player.play();
+    });
+
+    it('should send PLAY event and check jointime w/o preload', done => {
+      const STATIC_NOW = Date.now() + 3000;
+
+      sandbox.stub(OVPAnalyticsService, 'trackEvent').callsFake((serviceUrl, params) => {
+        try {
+          if (params.eventType === KavaEventModel.PLAY.index) {
+            params.joinTime.should.not.equal(kava.constructor._getTimeDifferenceInSeconds(kava._firstPlayRequestTime));
+            params.joinTime.should.equal(kava.constructor._getTimeDifferenceInSeconds(kava._loadStartTime));
+            done();
+          }
+        } catch (err) {
+          done(err);
+        }
+
+        return new RequestBuilder();
+      });
+      setupPlayer(config);
+      kava = getKavaPlugin();
+      sandbox.stub(kava.constructor, '_getTimeDifferenceInSeconds').callsFake(time => {
+        return (STATIC_NOW - time) / 1000.0;
+      });
+
+      setTimeout(() => {
+        kava.dispatchEvent(player.Event.LOAD_START);
+      }, 200);
+      setTimeout(() => {
+        kava.dispatchEvent(player.Event.FIRST_PLAY);
+      }, 300);
+      setTimeout(() => {
+        kava.dispatchEvent(player.Event.PLAYING);
+      }, 400);
+    });
+
+    it('should send PLAY event and check jointime with auto preload', done => {
+      const STATIC_NOW = Date.now() + 3000;
+
+      sandbox.stub(OVPAnalyticsService, 'trackEvent').callsFake((serviceUrl, params) => {
+        try {
+          if (params.eventType === KavaEventModel.PLAY.index) {
+            params.joinTime.should.equal(kava.constructor._getTimeDifferenceInSeconds(kava._firstPlayRequestTime));
+            params.joinTime.should.not.equal(kava.constructor._getTimeDifferenceInSeconds(kava._loadStartTime));
+            done();
+          }
+        } catch (err) {
+          done(err);
+        }
+
+        return new RequestBuilder();
+      });
+      config.playback.preload = 'auto';
+      setupPlayer(config);
+      kava = getKavaPlugin();
+      sandbox.stub(kava.constructor, '_getTimeDifferenceInSeconds').callsFake(time => {
+        return (STATIC_NOW - time) / 1000.0;
+      });
+
+      setTimeout(() => {
+        kava.dispatchEvent(player.Event.LOAD_START);
+      }, 200);
+      setTimeout(() => {
+        kava.dispatchEvent(player.Event.FIRST_PLAY);
+      }, 300);
+      setTimeout(() => {
+        kava.dispatchEvent(player.Event.PLAYING);
+      }, 400);
+    });
+
+    it('should send PLAY event and check jointime with manual preload', done => {
+      const STATIC_NOW = Date.now() + 3000;
+
+      sandbox.stub(OVPAnalyticsService, 'trackEvent').callsFake((serviceUrl, params) => {
+        try {
+          if (params.eventType === KavaEventModel.PLAY.index) {
+            params.joinTime.should.equal(kava.constructor._getTimeDifferenceInSeconds(kava._firstPlayRequestTime));
+            params.joinTime.should.not.equal(kava.constructor._getTimeDifferenceInSeconds(kava._loadStartTime));
+            done();
+          }
+        } catch (err) {
+          done(err);
+        }
+
+        return new RequestBuilder();
+      });
+      setupPlayer(config);
+      kava = getKavaPlugin();
+      sandbox.stub(kava.constructor, '_getTimeDifferenceInSeconds').callsFake(time => {
+        return (STATIC_NOW - time) / 1000.0;
+      });
+
+      setTimeout(() => {
+        kava.dispatchEvent(player.Event.LOAD_START);
+      }, 100);
+      setTimeout(() => {
+        kava.dispatchEvent(player.Event.CAN_PLAY);
+      }, 200);
+      setTimeout(() => {
+        kava.dispatchEvent(player.Event.FIRST_PLAY);
+      }, 300);
+      setTimeout(() => {
+        kava.dispatchEvent(player.Event.PLAYING);
+      }, 400);
     });
 
     it('should send RESUME event', done => {


### PR DESCRIPTION
### Description of the Changes

Added units tests to jointime calc (original ticket was FEC-9575)
checked three scenarios - no preload, auto preload and manual preload.

solves FEC-9599

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
