### PR TITLE
feat(FEC-9566): add errorPosition (pre-playing or mid-stream) to error reporting

### DIFF
--- a/docs/kava-events.md
+++ b/docs/kava-events.md
@@ -8,6 +8,8 @@ Here you can see the list of all available KAVA Events:
 - [`PLAY`](#playEvent)
 - [`RESUME`](#resumeEvent)
 - [`PAUSE`](#pauseEvent)
+- [`BUFFER_START`](#bufferStartEvent)
+- [`BUFFER_END`](#bufferEndEvent)
 - [`REPLAY`](#replayEvent)
 - [`SEEK`](#seekEvent)
 - [`PLAY_REACHED_25_PERCENT`](#play25Event)
@@ -29,6 +31,7 @@ Here we will see some explanation about each event. When does it sent and what p
 
 - Event ID: `99`
 - Event Parameters:
+
   - [`COMMON_PARAMS`](./kava-parameters.md#common_params)
   - [`playTimeSum`](./kava-parameters.md#playTimeSum)
   - [`bufferTime`](./kava-parameters.md#bufferTime)
@@ -47,7 +50,7 @@ Here we will see some explanation about each event. When does it sent and what p
   - [`networkConnectionOverhead`](./kava-parameters.md#networkConnectionOverhead)
   - [`flavorParamsId`](./kava-parameters.md#flavorParamsId)
   - [`playbackSpeed`](./kava-parameters.md#playbackSpeed)
-  
+
 - Sent on first play and every 10 seconds of active playback (when player is paused, view timer should be paused/stopped).
 - 30 seconds without VIEW event will reset KAVA session, so all the VIEW [specific parameters](#endSessionResetParams) should be reset also.
 - Server may notify Kava (via response field ["viewEventsEnabled" = false](#serverResponse)) to shut down VIEW events. When it happens, VIEW events should be blocked from sending until server decides to enable VIEW events again.
@@ -113,6 +116,24 @@ Here we will see some explanation about each event. When does it sent and what p
 - Event Parameters:
   - [`COMMON_PARAMS`](./kava-parameters.md#common_params)
 - Replay should reset all the parameters related to playback except `PLAYER_REACHED` events.
+
+---
+
+<a id="bufferStartEvent"></a>`BUFFER_START` - Sent when playback buffering started.
+
+- Event ID: `45`
+- Player Event: `BUFFER_START`
+- Event Parameters:
+  - [`COMMON_PARAMS`](./kava-parameters.md#common_params)
+
+---
+
+<a id="bufferEndEvent"></a>`BUFFER_END` - Sent when playback buffering ended.
+
+- Event ID: `46`
+- Player Event: `BUFFER_END`
+- Event Parameters:
+  - [`COMMON_PARAMS`](./kava-parameters.md#common_params)
 
 ---
 
@@ -224,3 +245,5 @@ No matter if by seeking or regular playback.
 - Event Parameters:
   - [`COMMON_PARAMS`](./kava-parameters.md#common_params)
   - [`errorCode`](./kava-parameters.md#errorCode)
+  - [`errorDetails`](./kava-parameters.md#errorDetails)
+  - [`errorPosition`](./kava-parameters.md#errorPosition)

--- a/docs/kava-parameters.md
+++ b/docs/kava-parameters.md
@@ -173,6 +173,23 @@ Kava parameters are additional data that is sent with Kava event and represent r
 
 ---
 
+<a id="errorDetails"></a>`errorDetails` - Additional data of the error.
+
+- Should be in format of String (Stringified from JSON)
+
+---
+
+<a id="errorPosition"></a>`errorPosition` - The position of the stream when the error occured (pre playing / mid stream).
+This is in addition to the `position` field which in live streams represents the offset from the live edge and therefore cannot
+be used to differ between pre-playing and mid streaming.
+
+- Should be in format of integer.
+- Possible values
+  - 1 - pre-playing stream error
+  - 2 - mid stream error
+
+---
+
 <a id="joinTime"></a>`joinTime` - Time that took to player start active playback for the first time.
 
 - Obtained by calculating time that passed from first PLAY_REQUEST to PLAY event.

--- a/src/kava-event-model.js
+++ b/src/kava-event-model.js
@@ -266,7 +266,8 @@ export const KavaEventModel: {[event: string]: KavaEvent} = {
     index: 98,
     getEventModel: (model: KavaModel) => ({
       errorCode: model.getErrorCode(),
-      errorDetails: model.getErrorDetails()
+      errorDetails: model.getErrorDetails(),
+      errorPosition: model.getErrorPosition()
     })
   }
 };

--- a/src/kava-model.js
+++ b/src/kava-model.js
@@ -10,6 +10,7 @@ import {getEventModel} from './kava-event-model';
 class KavaModel {
   sessionStartTime: number;
   eventIndex: number;
+  errorPosition: number;
   playTimeSum: number;
   bufferTime: number;
   bufferTimeSum: number;
@@ -299,6 +300,16 @@ class KavaModel {
   }
 
   /**
+   * Gets the error position (start or mid playing)
+   * @returns {number} - The error position - 1 for pre playing, 2 for mid stream error
+   * @memberof KavaModel
+   * @instance
+   */
+  getErrorPosition(): number {
+    return this.errorPosition;
+  }
+
+  /**
    * Gets the session start time.
    * @returns {number} - The session start time.
    * @memberof KavaModel
@@ -341,4 +352,9 @@ const TabMode = {
   TAB_FOCUSED: 2
 };
 
-export {KavaModel, SoundMode, TabMode};
+const ErrorPosition = {
+  PRE_PLAYING: 1,
+  MID_STREAM: 2
+};
+
+export {KavaModel, SoundMode, TabMode, ErrorPosition};

--- a/src/kava.js
+++ b/src/kava.js
@@ -4,7 +4,7 @@ import {OVPAnalyticsService} from 'playkit-js-providers/dist/playkit-analytics-s
 import {KavaEventModel, KavaEventType} from './kava-event-model';
 import {KavaRateHandler} from './kava-rate-handler';
 import {KavaTimer} from './kava-timer';
-import {KavaModel, SoundMode, TabMode} from './kava-model';
+import {ErrorPosition, KavaModel, SoundMode, TabMode} from './kava-model';
 
 const DIVIDER: number = 1024;
 const TEXT_TYPE: string = 'TEXT';
@@ -638,7 +638,11 @@ class Kava extends BasePlugin {
 
   _onError(event: FakeEvent): void {
     if (event.payload && event.payload.severity === PKError.Severity.CRITICAL) {
-      this._model.updateModel({errorCode: event.payload.code, errorDetails: event.payload.data});
+      this._model.updateModel({
+        errorCode: event.payload.code,
+        errorDetails: event.payload.data,
+        errorPosition: this._isFirstPlay ? ErrorPosition.PRE_PLAYING : ErrorPosition.MID_STREAM
+      });
       this._sendAnalytics(KavaEventModel.ERROR);
       this.reset();
     }

--- a/test/src/kava-event-model.spec.js
+++ b/test/src/kava-event-model.spec.js
@@ -41,6 +41,10 @@ class FakeModel {
     return {};
   }
 
+  getErrorPosition() {
+    return 1;
+  }
+
   getActualBitrate() {
     return 720;
   }
@@ -253,7 +257,8 @@ describe('KavaEventModel', () => {
     KavaEventModel.ERROR.index.should.equal(98);
     KavaEventModel.ERROR.getEventModel(fakeModel).should.deep.equal({
       errorCode: fakeModel.getErrorCode(),
-      errorDetails: fakeModel.getErrorDetails()
+      errorDetails: fakeModel.getErrorDetails(),
+      errorPosition: fakeModel.getErrorPosition()
     });
   });
 


### PR DESCRIPTION
…

### Description of the Changes

In order to be able to differ between video start and in-stream error, we need the player to add some metadata so that those two can be separated.

Today, the position (time) is used, however this cannot be used for LIVE as the position there related to a different thing.

On the error event we need to report the following:

errorPosition=1 or errorPosition=2

1 is start error
2 is mid stream error

solves FEC-9566

In addition - fixed a failed test in view event which passed travis because of missing try catch and added missing docs for buffer_start, buffer_end and errorDetails

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
