### PR TITLE
fix(FEC-9620): join time not calculated correctly in progressive videos

### DIFF
--- a/test/src/kava.spec.js
+++ b/test/src/kava.spec.js
@@ -268,10 +268,10 @@ describe('KavaPlugin', function() {
       });
 
       setTimeout(() => {
-        kava.dispatchEvent(player.Event.LOAD_START);
+        kava.dispatchEvent(player.Event.PLAYBACK_START);
       }, 200);
       setTimeout(() => {
-        kava.dispatchEvent(player.Event.FIRST_PLAY);
+        kava.dispatchEvent(player.Event.LOAD_START);
       }, 300);
       setTimeout(() => {
         kava.dispatchEvent(player.Event.PLAYING);
@@ -328,6 +328,7 @@ describe('KavaPlugin', function() {
 
         return new RequestBuilder();
       });
+      config.playback.preload = 'none';
       setupPlayer(config);
       kava = getKavaPlugin();
       sandbox.stub(kava.constructor, '_getTimeDifferenceInSeconds').callsFake(time => {
@@ -338,7 +339,7 @@ describe('KavaPlugin', function() {
         kava.dispatchEvent(player.Event.LOAD_START);
       }, 100);
       setTimeout(() => {
-        kava.dispatchEvent(player.Event.CAN_PLAY);
+        kava.dispatchEvent(player.Event.PLAYBACK_START);
       }, 200);
       setTimeout(() => {
         kava.dispatchEvent(player.Event.FIRST_PLAY);


### PR DESCRIPTION
### Description of the Changes

 because video events are same in progressive video - preload and regular then the manual preload is now relying on checking wether the playbackstart occured on load.

solves FEC-9620

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [X] new unit / functional tests have been added (whenever applicable)
- [X] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
