### PR TITLE
fix(FEC-9532): droppedFramesRatio = NaN instead of being between 0 and 1

### DIFF
--- a/src/kava.js
+++ b/src/kava.js
@@ -400,7 +400,7 @@ class Kava extends BasePlugin {
       const lastTotalFrames = droppedAndDecoded[1];
       droppedFramesDelta = lastDroppedFrames - this._lastDroppedFrames;
       totalFramesDelta = lastTotalFrames - this._lastTotalFrames;
-      droppedFrames = Math.round((droppedFramesDelta / totalFramesDelta) * 1000) / 1000;
+      droppedFrames = totalFramesDelta ? Math.round((droppedFramesDelta / totalFramesDelta) * 1000) / 1000 : 0;
 
       this._lastTotalFrames = lastTotalFrames;
       this._lastDroppedFrames = lastDroppedFrames;

--- a/test/src/kava.spec.js
+++ b/test/src/kava.spec.js
@@ -83,6 +83,20 @@ describe('KavaPlugin', function() {
     kava._timePercentEvent.PLAY_REACHED_100_PERCENT.should.be.false;
   });
 
+  it('should check _getDroppedFramesRatio does not return NaN if no new frames received', done => {
+    let sandbox = sinon.sandbox.create();
+    setupPlayer(config);
+    kava = getKavaPlugin();
+    sandbox.stub(kava, '_getDroppedAndDecodedFrames').callsFake(() => {
+      return [20, 120];
+    });
+    let droppedFramesRatio;
+    droppedFramesRatio = kava._getDroppedFramesRatio();
+    droppedFramesRatio = kava._getDroppedFramesRatio();
+    droppedFramesRatio.should.equal(0);
+    done();
+  });
+
   describe('SendAnalytics', () => {
     let sandbox = sinon.sandbox.create();
     const config = {


### PR DESCRIPTION
### Description of the Changes

When there were no new frames increasing (for example, when buffering) then the total frames and the dropped frames are same the calculation had inside 0/0 which is NaN.
I added a check that if the total frames is same then return 0 as the droppedFramesRatio.

solves FEC-9532

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [X] new unit / functional tests have been added (whenever applicable)
- [X] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
