### PR TITLE
feat(FEC-9633): send UUID with analytics events

### DIFF
--- a/docs/configuration-api.md
+++ b/docs/configuration-api.md
@@ -60,6 +60,7 @@ Type: [Object][41]
 - `customVar2` **[Object][41]?** Custom objects field.
 - `customVar3` **[Object][41]?** Custom objects field.
 - `userId` **[string][42]?** custom user id .
+- `persistentSessionId` **[string][42]?** UUID for anonymous users.
 
 ### Examples
 

--- a/src/kava-event-model.js
+++ b/src/kava-event-model.js
@@ -327,6 +327,9 @@ export function getEventModel(eventObj: KavaEvent, model: KavaModel): Object {
   if (model.getUserId()) {
     commonModel.userId = model.getUserId();
   }
+  if (model.getPersistentSessionId()) {
+    commonModel.persistentSessionId = model.getPersistentSessionId();
+  }
   const eventModel = eventObj.getEventModel(model);
   return Object.assign(eventModel, commonModel);
 }

--- a/src/kava-model.js
+++ b/src/kava-model.js
@@ -56,6 +56,7 @@ class KavaModel {
   getApplicationVersion: Function;
   getUserId: Function;
   getCanPlayTime: Function;
+  getPersistentSessionId: Function;
 
   constructor(model?: Object) {
     if (model) {

--- a/src/kava.js
+++ b/src/kava.js
@@ -708,6 +708,7 @@ class Kava extends BasePlugin {
     this._model.getEntryId = () => this.config.entryId;
     this._model.getPlaylistId = () => this.config.playlistId;
     this._model.getSessionId = () => this.config.sessionId;
+    this._model.getPersistentSessionId = () => this.config.persistentSessionId;
     this._model.getClientVer = () => this.config.playerVersion;
     this._model.getClientTag = () => 'html5:v' + this.config.playerVersion;
     this._model.getKS = () => this.config.ks;

--- a/test/src/kava-model.spec.js
+++ b/test/src/kava-model.spec.js
@@ -30,7 +30,8 @@ const ab = 3,
   pc = 'pc',
   av = 'av',
   usi = '1234',
-  pbs = 1;
+  pbs = 1,
+  psi = '1234-1234';
 
 describe('KavaModel', () => {
   let model;
@@ -84,6 +85,7 @@ describe('KavaModel', () => {
     model.getApplicationVersion = () => av;
     model.getUserId = () => usi;
     model.getPlaybackSpeed = () => pbs;
+    model.getPersistentSessionId = () => psi;
   });
 
   it('should update the model', function() {
@@ -119,7 +121,8 @@ describe('KavaModel', () => {
       applicationVer: av,
       userId: usi,
       playbackSpeed: pbs,
-      caption: cap
+      caption: cap,
+      persistentSessionId: psi
     });
   });
 });

--- a/test/src/kava.spec.js
+++ b/test/src/kava.spec.js
@@ -183,6 +183,21 @@ describe('KavaPlugin', function() {
       player.play();
     });
 
+    it('should send IMPRESSION event with persistentSessionId set in setup', done => {
+      sandbox.stub(OVPAnalyticsService, 'trackEvent').callsFake((serviceUrl, params) => {
+        if (params.eventType === KavaEventModel.IMPRESSION.index) {
+          params.persistentSessionId.should.equal(configCopy.plugins.kava.persistentSessionId);
+          done();
+        }
+        return new RequestBuilder();
+      });
+      const configCopy = JSON.parse(JSON.stringify(config));
+      configCopy.plugins.kava.persistentSessionId = '74709497-d3a5-4d93-a866-0d171f65c8b0';
+      setupPlayer(configCopy);
+      kava = getKavaPlugin();
+      player.play();
+    });
+
     it('should send IMPRESSION event with playerJSLoadTime', done => {
       sandbox.stub(window.performance, 'getEntriesByType').callsFake(() => {
         return [
@@ -677,6 +692,21 @@ describe('KavaPlugin', function() {
       kava = getKavaPlugin();
       kava._model.updateModel({caption: 'eng'});
       player.play();
+    });
+
+    it('should send VIEW event with persistentSessionId set after setup using configure', done => {
+      sandbox.stub(OVPAnalyticsService, 'trackEvent').callsFake((serviceUrl, params) => {
+        if (params.eventType === KavaEventModel.VIEW.index) {
+          params.persistentSessionId.should.equal('74709497-d3a5-4d93-a866-0d171123');
+          done();
+        }
+        return new RequestBuilder();
+      });
+
+      setupPlayer(config);
+      kava = getKavaPlugin();
+      player.play();
+      player.configure({plugins: {kava: {persistentSessionId: '74709497-d3a5-4d93-a866-0d171123'}}});
     });
 
     it('should send first VIEW event with manifest download time, segment download time, bandwidth, networkConnectionOverhead', done => {


### PR DESCRIPTION
### Description of the Changes
Many of the playbacks hits are done by anonymous users and currently, we have no way to distinguish between them. 
Therefore we enable to pass persisentSessionId in kava config which will be sent in all events (once it is given - can be given in initial setup or through configure API)

solves FEC-9633

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [X] new unit / functional tests have been added (whenever applicable)
- [X] test are passing in local environment 
- [X] Travis tests are passing (or test results are not worse than on master branch :))
- [X] Docs have been updated
