### PR TITLE
feat(FEC-10615): support sending Kava beacons as POST

### DIFF
--- a/docs/configuration-api.md
+++ b/docs/configuration-api.md
@@ -50,6 +50,7 @@ Type: [Object][41]
 ### Properties
 
 - `serviceUrl` **[string][42]?** The Kaltura API server.
+- `requestMethod` **[string][42]?** The http method to be used for sending the beacons, GET or POST, the default is GET.
 - `viewEventCountdown` **[number][43]?** The interval in seconds that VIEW event will be sent.
 - `resetSessionCountdown` **[number][43]?** The interval in seconds that Kava session will be reset.
 - `dvrThreshold` **[number][43]?** Threshold in seconds from the live edge.
@@ -68,6 +69,7 @@ Type: [Object][41]
 // Default config
 {
  serviceUrl: '//analytics.kaltura.com/api_v3/index.php',
+ requestMethod: 'GET',
  viewEventCountdown: 30,
  resetSessionCountdown: 30,
  dvrThreshold: 120,

--- a/flow-typed/types/kava-http-method-type.js
+++ b/flow-typed/types/kava-http-method-type.js
@@ -1,0 +1,2 @@
+// @flow
+declare type KavaHttpMethodType = {[stream: string]: string};

--- a/src/http-method-type.js
+++ b/src/http-method-type.js
@@ -1,0 +1,7 @@
+// @flow
+const HttpMethodType: KavaHttpMethodType = {
+  GET: 'GET',
+  POST: 'POST'
+};
+
+export {HttpMethodType};

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ const NAME = __NAME__;
 
 export {Kava as Plugin};
 export {KavaEventType as EventType} from './kava-event-model';
+export {HttpMethodType} from './http-method-type';
 export {VERSION, NAME};
 
 const pluginName: string = 'kava';

--- a/src/kava.js
+++ b/src/kava.js
@@ -49,6 +49,7 @@ class Kava extends BasePlugin {
    */
   static defaultConfig: Object = {
     serviceUrl: `${Utils.Http.protocol}//analytics.kaltura.com/api_v3/index.php`,
+    requestMethod: 'GET',
     viewEventCountdown: 10,
     resetSessionCountdown: 30,
     dvrThreshold: 120,
@@ -206,7 +207,7 @@ class Kava extends BasePlugin {
    */
   sendAnalytics(model: Object): Promise<*> {
     return new Promise((resolve, reject) => {
-      OVPAnalyticsService.trackEvent(this.config.serviceUrl, model)
+      OVPAnalyticsService.trackEvent(this.config.serviceUrl, model, this.config.requestMethod)
         .doHttpRequest()
         .then(
           response => {

--- a/src/kava.js
+++ b/src/kava.js
@@ -5,6 +5,7 @@ import {KavaEventModel, KavaEventType} from './kava-event-model';
 import {KavaRateHandler} from './kava-rate-handler';
 import {KavaTimer} from './kava-timer';
 import {ErrorPosition, KavaModel, SoundMode, TabMode, ScreenMode} from './kava-model';
+import {HttpMethodType} from './http-method-type';
 
 const {Error: PKError, FakeEvent, Utils} = core;
 const DIVIDER: number = 1024;
@@ -49,7 +50,7 @@ class Kava extends BasePlugin {
    */
   static defaultConfig: Object = {
     serviceUrl: `${Utils.Http.protocol}//analytics.kaltura.com/api_v3/index.php`,
-    requestMethod: 'GET',
+    requestMethod: HttpMethodType.GET,
     viewEventCountdown: 10,
     resetSessionCountdown: 30,
     dvrThreshold: 120,

--- a/test/src/kava.spec.js
+++ b/test/src/kava.spec.js
@@ -885,7 +885,11 @@ describe('KavaPlugin', function () {
         })
       );
       player.dispatchEvent(
-        new FakeEvent(CustomEventType.FRAG_LOADED, {miliSeconds: FRAG2_DOWNLOAD_TIME, bytes: FRAG2_BYTES, url: 'http://www.somesite.com/movie2.ts'})
+        new FakeEvent(CustomEventType.FRAG_LOADED, {
+          miliSeconds: FRAG2_DOWNLOAD_TIME,
+          bytes: FRAG2_BYTES,
+          url: 'http://www.somesite.com/movie2.ts'
+        })
       );
       let performanceOverserList = {};
       performanceOverserList.getEntries = () => {
@@ -1067,6 +1071,21 @@ describe('KavaPlugin', function () {
       setupPlayer(config);
       kava = getKavaPlugin();
       kava._onPlaybackRateChanged();
+    });
+
+    it('should send IMPRESSION event as POST', done => {
+      sandbox.stub(OVPAnalyticsService, 'trackEvent').callsFake((serviceUrl, params, requestMethod) => {
+        try {
+          requestMethod.should.be.equal('POST');
+          done();
+        } catch (e) {
+          done(e);
+        }
+      });
+      config.plugins.kava.requestMethod = 'POST';
+      setupPlayer(config);
+      kava = getKavaPlugin();
+      player.play();
     });
   });
 

--- a/test/src/kava.spec.js
+++ b/test/src/kava.spec.js
@@ -4,6 +4,7 @@ import * as TestUtils from './utils/test-utils';
 import {OVPAnalyticsService, RequestBuilder} from 'playkit-js-providers/dist/playkit-analytics-service';
 import {KavaEventModel} from '../../src/kava-event-model';
 import {ErrorPosition, SoundMode, TabMode, ScreenMode} from '../../src/kava-model';
+import {HttpMethodType} from '../../src/http-method-type';
 
 const {FakeEvent, CustomEventType} = core;
 const targetId = 'player-placeholder_kava.spec';
@@ -1076,13 +1077,13 @@ describe('KavaPlugin', function () {
     it('should send IMPRESSION event as POST', done => {
       sandbox.stub(OVPAnalyticsService, 'trackEvent').callsFake((serviceUrl, params, requestMethod) => {
         try {
-          requestMethod.should.be.equal('POST');
+          requestMethod.should.be.equal(HttpMethodType.POST);
           done();
         } catch (e) {
           done(e);
         }
       });
-      config.plugins.kava.requestMethod = 'POST';
+      config.plugins.kava.requestMethod = HttpMethodType.POST;
       setupPlayer(config);
       kava = getKavaPlugin();
       player.play();


### PR DESCRIPTION
### Description of the Changes

add `requestMethod` config (`GET` by default) and send it to `OVPAnalyticsService.trackEvent`

Depends on https://github.com/kaltura/playkit-js-providers/pull/125

Solves FEC-10615

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
