### PR TITLE
fix(FEC-11971): when in PiP mode user is considered not engaged

### DIFF
--- a/src/kava.js
+++ b/src/kava.js
@@ -800,7 +800,7 @@ class Kava extends BasePlugin {
   _updateTabModeInModel(hiddenAttr: string): void {
     this._model.updateModel({
       // $FlowFixMe
-      tabMode: document[hiddenAttr] ? TabMode.TAB_NOT_FOCUSED : TabMode.TAB_FOCUSED
+      tabMode: document[hiddenAttr] && !this.player.isInPictureInPicture() ? TabMode.TAB_NOT_FOCUSED : TabMode.TAB_FOCUSED
     });
   }
 

--- a/src/kava.js
+++ b/src/kava.js
@@ -800,8 +800,12 @@ class Kava extends BasePlugin {
   _updateTabModeInModel(hiddenAttr: string): void {
     this._model.updateModel({
       // $FlowFixMe
-      tabMode: document[hiddenAttr] && !this.player.isInPictureInPicture() ? TabMode.TAB_NOT_FOCUSED : TabMode.TAB_FOCUSED
+      tabMode: this._isTabHidden(hiddenAttr) && !this.player.isInPictureInPicture() ? TabMode.TAB_NOT_FOCUSED : TabMode.TAB_FOCUSED
     });
+  }
+
+  _isTabHidden(hiddenAttr: string): boolean {
+    return document[hiddenAttr];
   }
 
   _initTabMode(): void {

--- a/src/kava.js
+++ b/src/kava.js
@@ -102,7 +102,7 @@ class Kava extends BasePlugin {
 
   _updateViewabilityModeInModel(isVisible: boolean): void {
     this._model.updateModel({
-      viewabilityMode: isVisible ? ViewabilityMode.IN_VIEW : ViewabilityMode.NOT_IN_VIEW
+      viewabilityMode: isVisible || this.player.isInPictureInPicture() ? ViewabilityMode.IN_VIEW : ViewabilityMode.NOT_IN_VIEW
     });
   }
 

--- a/test/src/kava.spec.js
+++ b/test/src/kava.spec.js
@@ -1151,8 +1151,9 @@ describe('KavaPlugin', function () {
       setupPlayer(config);
       sandbox.stub(player, 'isInPictureInPicture').returns(true);
       kava = getKavaPlugin();
-      player.play();
       kava._updateViewabilityModeInModel(false);
+      sandbox.stub(kava, '_updateViewabilityModeInModel').callsFake(() => {});
+      player.play();
     });
 
     it('should send VIEW event with viewabilityMode set to not in view when not in pip mode and player is not visible', done => {
@@ -1170,8 +1171,9 @@ describe('KavaPlugin', function () {
       setupPlayer(config);
       sandbox.stub(player, 'isInPictureInPicture').returns(false);
       kava = getKavaPlugin();
-      player.play();
       kava._updateViewabilityModeInModel(false);
+      sandbox.stub(kava, '_updateViewabilityModeInModel').callsFake(() => {});
+      player.play();
     });
   });
 

--- a/test/src/kava.spec.js
+++ b/test/src/kava.spec.js
@@ -1095,6 +1095,85 @@ describe('KavaPlugin', function () {
       kava = getKavaPlugin();
       player.play();
     });
+
+    it('should send VIEW event with tabMode set to focused when in pip and tab is hidden', done => {
+      sandbox.stub(OVPAnalyticsService, 'trackEvent').callsFake((serviceUrl, params) => {
+        if (params.eventType === KavaEventModel.VIEW.index) {
+          try {
+            params.tabMode.should.equal(TabMode.TAB_FOCUSED);
+            done();
+          } catch (e) {
+            done(e);
+          }
+        }
+        return new RequestBuilder();
+      });
+      setupPlayer(config);
+      sandbox.stub(player, 'isInPictureInPicture').returns(true);
+      kava = getKavaPlugin();
+      sandbox.stub(kava, '_isTabHidden').returns(true);
+      kava._updateTabModeInModel('hidden');
+      player.play();
+    });
+
+    it('should send VIEW event with tabMode set to not focused when not in pip and tab is hidden', done => {
+      sandbox.stub(OVPAnalyticsService, 'trackEvent').callsFake((serviceUrl, params) => {
+        if (params.eventType === KavaEventModel.VIEW.index) {
+          try {
+            params.tabMode.should.equal(TabMode.TAB_NOT_FOCUSED);
+            done();
+          } catch (e) {
+            done(e);
+          }
+        }
+        return new RequestBuilder();
+      });
+      setupPlayer(config);
+      sandbox.stub(player, 'isInPictureInPicture').returns(false);
+      kava = getKavaPlugin();
+      sandbox.stub(kava, '_isTabHidden').returns(true);
+      kava._updateTabModeInModel('hidden');
+      player.play();
+    });
+
+    it('should send VIEW event with viewabilityMode set to in view when in pip mode and player is not visible', done => {
+      sandbox.stub(OVPAnalyticsService, 'trackEvent').callsFake((serviceUrl, params) => {
+        if (params.eventType === KavaEventModel.VIEW.index) {
+          try {
+            params.viewabilityMode.should.equal(ViewabilityMode.IN_VIEW);
+            done();
+          } catch (e) {
+            done(e);
+          }
+        }
+        return new RequestBuilder();
+      });
+      setupPlayer(config);
+      sandbox.stub(player, 'isInPictureInPicture').returns(true);
+      kava = getKavaPlugin();
+      console.log(kava._model);
+      player.play();
+      kava._updateViewabilityModeInModel(false);
+    });
+
+    it('should send VIEW event with viewabilityMode set to not in view when not in pip mode and player is not visible', done => {
+      sandbox.stub(OVPAnalyticsService, 'trackEvent').callsFake((serviceUrl, params) => {
+        if (params.eventType === KavaEventModel.VIEW.index) {
+          try {
+            params.viewabilityMode.should.equal(ViewabilityMode.NOT_IN_VIEW);
+            done();
+          } catch (e) {
+            done(e);
+          }
+        }
+        return new RequestBuilder();
+      });
+      setupPlayer(config);
+      sandbox.stub(player, 'isInPictureInPicture').returns(false);
+      kava = getKavaPlugin();
+      player.play();
+      kava._updateViewabilityModeInModel(false);
+    });
   });
 
   describe('Start Time', () => {

--- a/test/src/kava.spec.js
+++ b/test/src/kava.spec.js
@@ -1151,7 +1151,6 @@ describe('KavaPlugin', function () {
       setupPlayer(config);
       sandbox.stub(player, 'isInPictureInPicture').returns(true);
       kava = getKavaPlugin();
-      console.log(kava._model);
       player.play();
       kava._updateViewabilityModeInModel(false);
     });


### PR DESCRIPTION
### Description of the Changes

**the issue:**
when in pip mode and switching tabs, user is not considered as "engaged" in realtime dashboard analytics.

**root cause:** 
realtime analytics dashboard is considering "user engagement" when playback is unmuted and tab is focused. there are another 2 scenarios but they include fullscreen mode, which is irrelevant in case of pip mode.
when switching to another tab, kava plugin is sending view event with tabMode=notFocused even when in pip mode. hence, the realtime graph is showing that the user is not engaged.

**solution:**
kava plugin will report tabMode=focused in case we are in pip mode.
Note- changed also viewabilityMode to "in view" in case we are in pip mode. up until now, the viewabilityMode was "not in view" even when entering pip.

Solves FEC-11971

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
