### PR TITLE
fix(FEC-13039):  ignore reporting playback rate values which are given to player programmatically and are not defined in the list

### DIFF
--- a/src/kava.js
+++ b/src/kava.js
@@ -675,7 +675,9 @@ class Kava extends BasePlugin {
   }
 
   _onPlaybackRateChanged(): void {
-    this._sendAnalytics(KavaEventModel.SPEED);
+    if (!this.player.playbackRates.length || this.player.playbackRates.includes(this.player.playbackRate)) {
+      this._sendAnalytics(KavaEventModel.SPEED);
+    }
   }
 
   _onPlayerStateChanged(event: FakeEvent): void {


### PR DESCRIPTION
solves: https://kaltura.atlassian.net/browse/FEC-13039

Dual-screen can change playback rate to synchronise playback of 2 medias. Kava plugin should ignore playback rate changes that made programmatically and not includes in available playback rates list.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
