### PR TITLE
SUP-37601:Social Highlights - Shares analytics not working on V7

### DIFF
--- a/src/kava-event-model.js
+++ b/src/kava-event-model.js
@@ -283,6 +283,18 @@ export const KavaEventModel: {[event: string]: KavaEvent} = {
     type: 'RELATED_SELECTED',
     index: 37,
     getEventModel: () => ({})
+  },
+  SHARE_CLICKED: {
+    type: 'SHARE_CLICKED',
+    index: 21,
+    getEventModel: () => ({})
+  },
+  SHARE_NETWORK: {
+    type: 'SHARE_NETWORK',
+    index: 22,
+    getEventModel: (model: KavaModel) => ({
+      socialNetwork: model.getShareNetworkName()
+    })
   }
 };
 

--- a/src/kava-model.js
+++ b/src/kava-model.js
@@ -36,6 +36,7 @@ class KavaModel {
   flavorParamsId: number = NaN;
   networkConnectionType: string;
   playerJSLoadTime: ?number = null;
+  shareNetworkName: ?string = NaN;
   getActualBitrate: Function;
   getPlaybackSpeed: Function;
   getAverageBitrate: Function;
@@ -344,6 +345,16 @@ class KavaModel {
    */
   getSessionStartTime(): number {
     return this.sessionStartTime;
+  }
+
+  /**
+   * Gets the share network name.
+   * @returns {number} - The session start time.
+   * @memberof KavaModel
+   * @instance
+   */
+  getShareNetworkName(): string {
+    return this.shareNetworkName;
   }
 
   /**

--- a/src/kava.js
+++ b/src/kava.js
@@ -325,6 +325,9 @@ class Kava extends BasePlugin {
     );
     this.eventManager.listen(this.player, RelatedEvent.RELATED_CLICKED, () => this._onRelatedClicked());
     this.eventManager.listen(this.player, RelatedEvent.RELATED_SELECTED, () => this._onRelatedSelected());
+    this.eventManager.listen(this.player, this.player.Event.SHARE_CLICKED, () => this._onShareClicked());
+    this.eventManager.listen(this.player, this.player.Event.SHARE_NETWORK, event => this._onShareNetworkClicked(event));
+
     this._initTabMode();
     this._initNetworkConnectionType();
   }
@@ -701,6 +704,18 @@ class Kava extends BasePlugin {
 
   _onRelatedSelected() {
     this._sendAnalytics(KavaEventModel.RELATED_SELECTED);
+  }
+
+  _onShareClicked() {
+    this._sendAnalytics(KavaEventModel.SHARE_CLICKED);
+  }
+
+  _onShareNetworkClicked(event: FakeEvent): void {
+    const shareNetworkName = event.payload.shareNetworkName;
+    if (shareNetworkName) {
+      this._model.updateModel({shareNetworkName: shareNetworkName});
+      this._sendAnalytics(KavaEventModel.SHARE_NETWORK);
+    }
   }
 
   _updateSessionStartTimeModel(response: Object | number): void {


### PR DESCRIPTION
the issue:
click share not send analytics.

the changes:
add 2 new events SHARE_CLICKED and SHARE_NETWORK that will send when clicked the buttons.
