### PR TITLE
fix - SUP-37601:Social Highlights - Shares analytics not working on V7

### DIFF
--- a/src/kava-model.js
+++ b/src/kava-model.js
@@ -36,7 +36,7 @@ class KavaModel {
   flavorParamsId: number = NaN;
   networkConnectionType: string;
   playerJSLoadTime: ?number = null;
-  shareNetworkName: ?string = NaN;
+  shareNetworkName: string = '';
   getActualBitrate: Function;
   getPlaybackSpeed: Function;
   getAverageBitrate: Function;


### PR DESCRIPTION
fix for default value for shareNetwork
