### PR TITLE
feat(FEC-13683): Pre/Post simulive analytics reporting

### DIFF
--- a/src/kava-event-model.ts
+++ b/src/kava-event-model.ts
@@ -57,6 +57,12 @@ export const KavaEventModel = {
       if (!isNaN(model.getFlavorParamsId())) {
         eventModel.flavorParamsId = model.getFlavorParamsId();
       }
+      if (!isNaN(model.getPlaybackMode())) {
+        eventModel.playbackMode = model.getPlaybackMode();
+      }
+      if (model.getSourceEntryId() !== null) {
+        eventModel.sourceEntryId = model.getSourceEntryId();
+      }
 
       return eventModel;
     }

--- a/src/kava-model.ts
+++ b/src/kava-model.ts
@@ -40,6 +40,9 @@ class KavaModel {
   public playerJSLoadTime?: number | null = null;
   private shareNetworkName: string = '';
   private reportType: number = NaN;
+  private playbackMode: number = NaN;
+  private sourceEntryId: string | null = null;
+
   public getActualBitrate!: () => any;
   public getPlaybackSpeed!: () => any;
   public getAverageBitrate!: () => any;
@@ -361,6 +364,14 @@ class KavaModel {
 
   public getReportType(): number {
     return this.reportType;
+  }
+
+  public getPlaybackMode(): number {
+    return this.playbackMode;
+  }
+
+  public getSourceEntryId(): string | null {
+    return this.sourceEntryId;
   }
 
   /**

--- a/src/kava.ts
+++ b/src/kava.ts
@@ -651,7 +651,29 @@ class Kava extends BasePlugin {
     const id3TagCues = event.payload.cues.filter((entry) => entry.value && entry.value.key === TEXT_TYPE);
     if (id3TagCues.length) {
       try {
-        this._model.updateModel({ flavorParamsId: Number(JSON.parse(id3TagCues[id3TagCues.length - 1].value.data).sequenceId) });
+        const data = JSON.parse(id3TagCues[id3TagCues.length - 1].value.data);
+        this._model.updateModel({ flavorParamsId: Number(data.sequenceId) });
+
+        if (data.clipId) {
+          const [partType, entryId] = data.clipId.split("-");
+
+          switch(partType) {
+            case "preStartContent": {
+              this._model.updateModel({ sourceEntryId: entryId, playbackMode: 1 });
+              break;
+            }
+            case "content": {
+              this._model.updateModel({ sourceEntryId: entryId, playbackMode: 2 });
+              break;
+            }
+            case "postEntryContent": {
+              this._model.updateModel({ sourceEntryId: entryId, playbackMode: 3 });
+              break;
+            }
+            default: 
+              break;
+          }
+        }
       } catch (e) {
         this.logger.debug('error parsing id3', e);
       }

--- a/test/e2e/kava-event-model.spec.js
+++ b/test/e2e/kava-event-model.spec.js
@@ -116,6 +116,14 @@ class FakeModel {
   getPlaybackSpeed() {
     return 2;
   }
+
+  getPlaybackMode() {
+    return 1;
+  }
+
+  getSourceEntryId() {
+    return "source_entry_id"
+  }
 }
 
 describe('KavaEventModel', () => {
@@ -143,7 +151,9 @@ describe('KavaEventModel', () => {
       targetBuffer: fakeModel.getTargetBuffer(),
       networkConnectionType: fakeModel.getNetworkConnectionType(),
       networkConnectionOverhead: fakeModel.getNetworkConnectionOverhead(),
-      flavorParamsId: fakeModel.getFlavorParamsId()
+      flavorParamsId: fakeModel.getFlavorParamsId(),
+      playbackMode: fakeModel.getPlaybackMode(),
+      sourceEntryId: fakeModel.getSourceEntryId()
     });
   });
 


### PR DESCRIPTION
### Description of the Changes

Add sourceEntryId and playbackMode to VIEW event model

Note that this does not handle sending an event only once if we seek back to a previous portion of the simulive. If we want to do that, we need to understand how to identify that we have already seen this portion - by entry id ? (and then what if we have the same entry id multiple times in the simulive playlist) ? 

Resolves FEC-13683

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
