### PR TITLE
fix(SUP-42252): Actual view time for clips is not correct

### DIFF
--- a/src/kava.ts
+++ b/src/kava.ts
@@ -875,16 +875,20 @@ class Kava extends BasePlugin {
   }
 
   private _getPosition(): number {
+    let currentTime = this.player.currentTime;
+    if (this.player.sources.seekFrom) {
+      currentTime += this.player.sources.seekFrom;
+    }
     if (this.player.isLive()) {
       if (!Number.isNaN(this.player.duration)) {
-        if (this.player.duration! - this.player.currentTime! < 1) {
+        if (this.player.duration! - currentTime! < 1) {
           return 0;
         }
-        return -(this.player.duration! - this.player.currentTime!);
+        return -(this.player.duration! - currentTime!);
       }
       return 0;
     }
-    return this._isFirstPlaying ? this.player.currentTime! || this.player.sources.startTime || 0 : this.player.currentTime!;
+    return this._isFirstPlaying ? currentTime! || this.player.sources.startTime || 0 : currentTime!;
   }
 
   private _getDeliveryType(): string {

--- a/src/kava.ts
+++ b/src/kava.ts
@@ -876,9 +876,6 @@ class Kava extends BasePlugin {
 
   private _getPosition(): number {
     let currentTime = this.player.currentTime;
-    if (this.player.sources.seekFrom && currentTime) {
-      currentTime += this.player.sources.seekFrom;
-    }
     if (this.player.isLive()) {
       if (!Number.isNaN(this.player.duration)) {
         if (this.player.duration! - currentTime! < 1) {
@@ -887,6 +884,9 @@ class Kava extends BasePlugin {
         return -(this.player.duration! - currentTime!);
       }
       return 0;
+    }
+    if (this.player.sources.seekFrom && currentTime) {
+      currentTime += this.player.sources.seekFrom;
     }
     return this._isFirstPlaying ? currentTime! || this.player.sources.startTime || 0 : currentTime!;
   }

--- a/src/kava.ts
+++ b/src/kava.ts
@@ -876,7 +876,7 @@ class Kava extends BasePlugin {
 
   private _getPosition(): number {
     let currentTime = this.player.currentTime;
-    if (this.player.sources.seekFrom) {
+    if (this.player.sources.seekFrom && currentTime) {
       currentTime += this.player.sources.seekFrom;
     }
     if (this.player.isLive()) {

--- a/src/kava.ts
+++ b/src/kava.ts
@@ -875,17 +875,17 @@ class Kava extends BasePlugin {
   }
 
   private _getPosition(): number {
-    let currentTime = this.player.currentTime;
     if (this.player.isLive()) {
       if (!Number.isNaN(this.player.duration)) {
-        if (this.player.duration! - currentTime! < 1) {
+        if (this.player.duration! - this.player.currentTime! < 1) {
           return 0;
         }
-        return -(this.player.duration! - currentTime!);
+        return -(this.player.duration! - this.player.currentTime!);
       }
       return 0;
     }
-    if (this.player.sources.seekFrom && currentTime) {
+    let currentTime = this.player.currentTime;
+    if (typeof this.player.sources.seekFrom === 'number' && currentTime) {
       currentTime += this.player.sources.seekFrom;
     }
     return this._isFirstPlaying ? currentTime! || this.player.sources.startTime || 0 : currentTime!;


### PR DESCRIPTION
### Description of the Changes

**Issue:**
When playing only part of video by using the seekFrom the duration and currentTime is calculated according to the new times. so the position value (sent to analytics) is calculated from start time =0 (even that this is not 0 in the fully video).

**Solution:** 
If seekFrom is defined, calculate the currentTime with the seekFrom value.

Solves [SUP-42252](https://kaltura.atlassian.net/browse/SUP-42252)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[SUP-42252]: https://kaltura.atlassian.net/browse/SUP-42252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ