### PR TITLE
feat(FEC-14469): Report playerSkin to player events kava bucket

### DIFF
--- a/src/application-events-model.ts
+++ b/src/application-events-model.ts
@@ -12,14 +12,12 @@ export function getApplicationEventsModel(eventObj: KavaEvent, model: KavaModel,
     partnerId: model.getPartnerId(),
     entryId: model.getEntryId(),
     sessionId: model.getSessionId(),
-    kalturaApplication: KalturaApplication.PLAYER
+    kalturaApplication: KalturaApplication.PLAYER,
+    application: model.getApplication(false)
   };
 
   if (model.getVirtualEventId()) {
     commonModel['virtualEventId'] = model.getVirtualEventId();
-  }
-  if (model.getKalturaApplication()) {
-    commonModel['application'] = model.getApplication();
   }
   if (model.getKalturaApplicationVersion()) {
     commonModel['kalturaApplicationVer'] = model.getKalturaApplicationVersion();

--- a/src/enums/player-skin.ts
+++ b/src/enums/player-skin.ts
@@ -1,0 +1,5 @@
+export enum PlayerSkin {
+  PLAYER = 1,
+  AUDIO = 2,
+  REELS = 3
+}

--- a/src/kava-event-model.ts
+++ b/src/kava-event-model.ts
@@ -374,7 +374,8 @@ export function getEventModel(eventObj: KavaEvent, model: KavaModel): any {
     clientVer: model.getClientVer(),
     clientTag: model.getClientTag(),
     position: model.getPosition(),
-    playbackSpeed: model.getPlaybackSpeed()
+    playbackSpeed: model.getPlaybackSpeed(),
+    playerSkin: model.getPlayerSkin()
   };
 
   if (model.getCaption()) {

--- a/src/kava-model.ts
+++ b/src/kava-model.ts
@@ -64,13 +64,14 @@ class KavaModel {
   public getDeliveryType!: () => any;
   public getPlaybackType!: () => any;
   public getPlaybackContext!: () => any;
-  public getApplication!: () => any;
+  public getApplication!: (playerEvent?: boolean) => any;
   public getKalturaApplicationVersion!: () => any;
   public getKalturaApplication!: () => any;
   public getUserId!: () => any;
   public getPersistentSessionId!: () => any;
   public getHostingKalturaApplication!: () => any;
   public getHostingKalturaApplicationVersion!: () => any;
+  public getPlayerSkin!: () => any;
 
   constructor(model?: object) {
     if (model) {

--- a/src/kava.ts
+++ b/src/kava.ts
@@ -13,6 +13,7 @@ import { PluginsEvents, PlaykitUIEvents } from './applications-events';
 import { EventBucketName } from './enums/event-bucket-name';
 import { ApplicationEventsModel, getApplicationEventsModel } from './application-events-model';
 import { Application } from './enums/application';
+import { PlayerSkin } from './enums/player-skin';
 
 const { Error: PKError, Utils } = core;
 const DIVIDER: number = 1024;
@@ -865,12 +866,17 @@ class Kava extends BasePlugin {
     this._model.getDeliveryType = (): string => this._getDeliveryType();
     this._model.getPlaybackType = (): string => this._getPlaybackType();
     this._model.getPlaybackContext = (): string => this.config.playbackContext;
-    this._model.getApplication = (): string => this._getPlayerType();
+    this._model.getApplication = (playerEvent?: boolean): string => this._getApplication(playerEvent);
     this._model.getKalturaApplicationVersion = (): string => this.config.kalturaApplicationVersion;
     this._model.getKalturaApplication = (): string => this._getKalturaApplicationId(this.config.kalturaApplication);
     this._model.getUserId = (): string => this.config.userId;
     this._model.getHostingKalturaApplication = (): string => this.config.application;
     this._model.getHostingKalturaApplicationVersion = (): string => this.config.applicationVersion;
+    this._model.getPlayerSkin = (): number => this._getPlayerSkin();
+  }
+
+  private _getApplication(playerEvent = true): string {
+    return playerEvent ? this.config.application : this._getPlayerType();
   }
 
   private _getPlayerType(): Application {
@@ -880,6 +886,16 @@ class Kava extends BasePlugin {
       return Application.AUDIO;
     } else {
       return Application.VIDEO;
+    }
+  }
+
+  private _getPlayerSkin(): PlayerSkin {
+    if (this.player.plugins.reels !== undefined) {
+      return PlayerSkin.REELS;
+    } else if (this.player.plugins.audioPlayer !== undefined) {
+      return PlayerSkin.AUDIO;
+    } else {
+      return PlayerSkin.PLAYER;
     }
   }
 

--- a/src/kava.ts
+++ b/src/kava.ts
@@ -876,6 +876,8 @@ class Kava extends BasePlugin {
   }
 
   private _getApplication(playerEvent = true): string {
+    // for player event, we want to return the application value from the configuration
+    // otherwise (i.e. application event), we want to return the player type
     return playerEvent ? this.config.application : this._getPlayerType();
   }
 

--- a/test/e2e/application-events.model.spec.js
+++ b/test/e2e/application-events.model.spec.js
@@ -9,7 +9,8 @@ const commonModel = {
   sessionId: '91011',
   kalturaApplication: KalturaApplication.PLAYER,
   eventType: undefined,
-  feature: undefined
+  feature: undefined,
+  application: undefined
 };
 
 describe('ApplicationEventsModel', () => {

--- a/test/e2e/kava-model.spec.js
+++ b/test/e2e/kava-model.spec.js
@@ -36,7 +36,8 @@ const ab = 3,
   ka = 'ka',
   usi = '1234',
   pbs = 1,
-  psi = '1234-1234';
+  psi = '1234-1234',
+  ps = 1;
 
 describe('KavaModel', () => {
   let model;
@@ -96,6 +97,7 @@ describe('KavaModel', () => {
     model.getPersistentSessionId = () => psi;
     model.getHostingKalturaApplication = () => hostingApp;
     model.getHostingKalturaApplicationVersion = () => av;
+    model.getPlayerSkin = () => ps;
   });
 
   it('should update the model', function () {
@@ -137,7 +139,8 @@ describe('KavaModel', () => {
       caption: cap,
       persistentSessionId: psi,
       hostingKalturaApplication: hostingApp,
-      hostingKalturaApplicationVersion: av
+      hostingKalturaApplicationVersion: av,
+      playerSkin: ps
     });
   });
 });

--- a/test/e2e/kava.spec.js
+++ b/test/e2e/kava.spec.js
@@ -803,7 +803,7 @@ describe('KavaPlugin', function () {
                 'tabMode',
                 'networkConnectionType',
                 'userId',
-                'application'
+                'playerSkin'
               );
               params.networkConnectionType.should.equal('2g');
               params.tabMode.should.equal(TabMode.TAB_FOCUSED);


### PR DESCRIPTION
### Description of the Changes

report `playerSkin` analytic. possible values:
- `1` - Player
- `2` - Audio
- `3` - Reels

also, fix a bug where `application` analytic for **player** events sends the wrong value (following [PR](https://github.com/kaltura/playkit-js-kava/pull/195/files)).
`application` analytic for player event should keep sending the value in `kava.config.application`, if exists.

Resolves [FEC-14469](https://kaltura.atlassian.net/browse/FEC-14469)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEC-14469]: https://kaltura.atlassian.net/browse/FEC-14469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ