### PR TITLE
fix(FEC-14617): Add Product analytics beacons for CPE tracker

### DIFF
--- a/src/application-events-model.ts
+++ b/src/application-events-model.ts
@@ -1066,5 +1066,16 @@ export const ApplicationEventsModel: { [playerEventName: string]: KavaEvent } = 
       eventVar4: payload.size,
       applicationFeature: ApplicationFeature.AUDIO_PLAYER
     })
+  },
+  [PluginsEvents.CPE_TRACKER_HOVER]: {
+    type: 'CPE_TRACKER_HOVER',
+    getEventModel: (): any => ({
+      eventType: ApplicationEventType.BUTTON_CLICKED,
+      eventVar2: ButtonType.Navigate,
+      eventVar1: 'CPE_tracker_hover',
+      eventVar3: '',
+      eventVar4: '',
+      applicationFeature: ApplicationFeature.CPE_TRACKER
+    })
   }
 };

--- a/src/applications-events.ts
+++ b/src/applications-events.ts
@@ -140,6 +140,16 @@ export const AudioPlayerEvents = {
   AUDIO_PLAYER_VISUALIZATION_STATE: 'audio_player_visualization_state'
 };
 
+export const CpeTrackerEvents = {
+  CPE_TRACKER_HOVER: 'cpe_tracker_hover'
+};
+
+// events fired by the kava plugin itself - the kava plugin does not listen to these events
+export const KavaEvents = {
+  KAVA_REQUEST_SUCCEEDED: 'kava_request_succeeded',
+  KAVA_REQUEST_FAILED: 'kava_request_failed'
+};
+
 export const PluginsEvents = {
   ...NavigationEvents,
   ...DownloadEvents,
@@ -157,5 +167,6 @@ export const PluginsEvents = {
   ...ReelsEvents,
   ...EadEvents,
   ...SummaryAndChaptersEvents,
-  ...AudioPlayerEvents
+  ...AudioPlayerEvents,
+  ...CpeTrackerEvents
 };

--- a/src/enums/application-feature.ts
+++ b/src/enums/application-feature.ts
@@ -20,5 +20,6 @@ export enum ApplicationFeature {
   AUDION_TRACKS = 'audio_tracks',
   SUMMARY_CHAPTERS = 'summary_chapters',
   DEBUG_INFO = 'debug_info',
-  AUDIO_PLAYER = 'audio_player'
+  AUDIO_PLAYER = 'audio_player',
+  CPE_TRACKER = 'cpe_tracker'
 }

--- a/src/kava.ts
+++ b/src/kava.ts
@@ -9,7 +9,7 @@ import { HttpMethodType } from './enums/http-method-type';
 import { KalturaApplication } from './enums/kaltura-application';
 import { KavaConfigObject, KavaEvent } from './types';
 import { DownloadEvent, InfoEvent, ModerationEvent, RelatedEvent, ShareEvent } from './temp-imported-plugins-event-names-temp';
-import { PluginsEvents, PlaykitUIEvents } from './applications-events';
+import { PluginsEvents, PlaykitUIEvents, KavaEvents } from './applications-events';
 import { EventBucketName } from './enums/event-bucket-name';
 import { ApplicationEventsModel, getApplicationEventsModel } from './application-events-model';
 import { Application } from './enums/application';
@@ -305,7 +305,7 @@ class Kava extends BasePlugin {
   private _handleServerResponseSuccess(response: any, model: any): void {
     this.logger.debug('KAVA event sent', model);
     const event: Partial<FakeEvent> = {
-      type: 'kavaRequestSucceeded',
+      type: KavaEvents.KAVA_REQUEST_SUCCEEDED,
       payload: { response, model }
     };
     this.player.dispatchEvent(event as FakeEvent);
@@ -318,8 +318,7 @@ class Kava extends BasePlugin {
     }
     this.logger.warn('Failed to send KAVA event', model, err);
     const event: Partial<FakeEvent> = {
-      // TODO try to export as type
-      type: 'kavaRequestFailed',
+      type: KavaEvents.KAVA_REQUEST_FAILED,
       payload: { error: err, model }
     };
     this.player.dispatchEvent(event as FakeEvent);


### PR DESCRIPTION
### Description of the Changes

Listen to CPE popup hover event
Rename events sent into player by the kava plugin into the standard A_B_C format

Related PR:
https://github.com/kaltura/playkit-js-cpe-tracker/pull/4
