### PR TITLE
feat(FEC-14656): Add product analytics for banner overlay plugin

### DIFF
--- a/src/application-events-model.ts
+++ b/src/application-events-model.ts
@@ -1077,5 +1077,27 @@ export const ApplicationEventsModel: { [playerEventName: string]: KavaEvent } = 
       eventVar4: '',
       applicationFeature: ApplicationFeature.CPE_TRACKER
     })
+  },
+  [PluginsEvents.BANNER_MESSAGE_DISPLAYS]: {
+    type: 'BANNER_MESSAGE_DISPLAYS',
+    getEventModel: (): any => ({
+      eventType: ApplicationEventType.PAGE_LOAD,
+      eventVar2: PageLoadType.Analytics,
+      eventVar1: 'banner_message_displays',
+      eventVar3: '',
+      eventVar4: '',
+      applicationFeature: ApplicationFeature.BANNER_OVERLAY
+    })
+  },
+  [PluginsEvents.BANNER_MESSAGE_MANUALLY_DISMISSED]: {
+    type: 'BANNER_MESSAGE_MANUALLY_DISMISSED',
+    getEventModel: (): any => ({
+      eventType: ApplicationEventType.BUTTON_CLICKED,
+      eventVar2: ButtonType.Close,
+      eventVar1: 'banner_message_manually_dismissed',
+      eventVar3: '',
+      eventVar4: '',
+      applicationFeature: ApplicationFeature.BANNER_OVERLAY
+    })
   }
 };

--- a/src/applications-events.ts
+++ b/src/applications-events.ts
@@ -144,6 +144,11 @@ export const CpeTrackerEvents = {
   CPE_TRACKER_HOVER: 'cpe_tracker_hover'
 };
 
+export const BannerOverlayEvents = {
+  BANNER_MESSAGE_DISPLAYS: 'banner_message_displays',
+  BANNER_MESSAGE_MANUALLY_DISMISSED: 'banner_message_manually_dismissed'
+};
+
 // events fired by the kava plugin itself - the kava plugin does not listen to these events
 export const KavaEvents = {
   KAVA_REQUEST_SUCCEEDED: 'kava_request_succeeded',
@@ -168,5 +173,6 @@ export const PluginsEvents = {
   ...EadEvents,
   ...SummaryAndChaptersEvents,
   ...AudioPlayerEvents,
-  ...CpeTrackerEvents
+  ...CpeTrackerEvents,
+  ...BannerOverlayEvents
 };

--- a/src/enums/application-feature.ts
+++ b/src/enums/application-feature.ts
@@ -21,5 +21,6 @@ export enum ApplicationFeature {
   SUMMARY_CHAPTERS = 'summary_chapters',
   DEBUG_INFO = 'debug_info',
   AUDIO_PLAYER = 'audio_player',
-  CPE_TRACKER = 'cpe_tracker'
+  CPE_TRACKER = 'cpe_tracker',
+  BANNER_OVERLAY = 'banner_overlay'
 }


### PR DESCRIPTION
- Adds new event constants for banner overlay: `BANNER_MESSAGE_DISPLAYS` and `BANNER_MESSAGE_MANUALLY_DISMISSED`.
- Integrates `BannerOverlayEvents` into the main `PluginsEvents` export.
- Updates `ApplicationEventsModel` to support the new banner overlay events and maps them to analytics models.
- Extends `ApplicationFeature` enum to include the `BANNER_OVERLAY` feature.

[FEC-14656](https://kaltura.atlassian.net/browse/FEC-14656)

[FEC-14656]: https://kaltura.atlassian.net/browse/FEC-14656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ