### PR TITLE
feat(FEC-15007): Live streaming: report primary vs secondary stream dimension to Kava on live playback events

### DIFF
--- a/src/kava-event-model.ts
+++ b/src/kava-event-model.ts
@@ -64,6 +64,11 @@ export const KavaEventModel = {
         eventModel.sourceEntryId = model.getSourceEntryId();
       }
 
+      const liveStreamType = model.getLiveStreamType();
+      if (liveStreamType !== undefined) {
+        eventModel.streamType = liveStreamType;
+      }
+
       return eventModel;
     }
   },

--- a/src/kava-model.ts
+++ b/src/kava-model.ts
@@ -74,6 +74,7 @@ class KavaModel {
   public getPlayerSkin!: () => any;
   public getV2ToV7Redirect!: () => any;
   public getNumFailedAnalyticReports!: () => number;
+  public getLiveStreamType!: () => number | undefined;
 
   constructor(model?: object) {
     if (model) {

--- a/src/kava.ts
+++ b/src/kava.ts
@@ -893,6 +893,7 @@ class Kava extends BasePlugin {
     this._model.getPlayerSkin = (): number => this._getPlayerSkin();
     this._model.getV2ToV7Redirect = (): boolean => this.player.isV2ToV7Redirected;
     this._model.getNumFailedAnalyticReports = (): number => this._logFailedLiveEvents.getNumFailedAnalyticReports(this.config.entryId);
+    this._model.getLiveStreamType = (): number | undefined => this._getLiveStreamType();
   }
 
   private _getApplication(playerEvent = true): string {
@@ -997,6 +998,16 @@ class Kava extends BasePlugin {
       // $FlowFixMe
       tabMode: this._isTabHidden(hiddenAttr) && !this.player.isInPictureInPicture() ? TabMode.TAB_NOT_FOCUSED : TabMode.TAB_FOCUSED
     });
+  }
+
+  private _getLiveStreamType(): number | undefined {
+    if (!this.player.isLive()) {
+      return undefined;
+    } 
+    const stValue = (this.player as any).getLiveEntryStValue?.();
+    if (stValue === '0') return 1;
+    if (stValue === '1') return 2;
+    return undefined;
   }
 
   private _isTabHidden(hiddenAttr: string): boolean {

--- a/src/kava.ts
+++ b/src/kava.ts
@@ -1005,6 +1005,7 @@ class Kava extends BasePlugin {
       return undefined;
     }
     const stValue = (this.player as any).getLiveEntryStValue?.();
+    // '0' = primary stream, '1' = backup stream
     if (stValue === '0') return 1;
     if (stValue === '1') return 2;
     return undefined;

--- a/src/kava.ts
+++ b/src/kava.ts
@@ -1003,7 +1003,7 @@ class Kava extends BasePlugin {
   private _getLiveStreamType(): number | undefined {
     if (!this.player.isLive()) {
       return undefined;
-    } 
+    }
     const stValue = (this.player as any).getLiveEntryStValue?.();
     if (stValue === '0') return 1;
     if (stValue === '1') return 2;

--- a/test/e2e/kava-event-model.spec.js
+++ b/test/e2e/kava-event-model.spec.js
@@ -132,6 +132,10 @@ class FakeModel {
   getV2ToV7Redirect() {
     return false;
   }
+
+  getLiveStreamType() {
+    return 1;
+  }
 }
 
 describe('KavaEventModel', () => {
@@ -161,7 +165,8 @@ describe('KavaEventModel', () => {
       networkConnectionOverhead: fakeModel.getNetworkConnectionOverhead(),
       flavorParamsId: fakeModel.getFlavorParamsId(),
       playbackMode: fakeModel.getPlaybackMode(),
-      sourceEntryId: fakeModel.getSourceEntryId()
+      sourceEntryId: fakeModel.getSourceEntryId(),
+      streamType: fakeModel.getLiveStreamType()
     });
   });
 


### PR DESCRIPTION
### Description of the Changes

Adding streamType filed on view event 

related pr: https://github.com/kaltura/kaltura-player-js/pull/1247, https://github.com/kaltura/playkit-js-hls/pull/247, https://github.com/kaltura/playkit-js-dash/pull/274, https://github.com/kaltura/playkit-js/pull/889

solves  [FEC-15007](https://kaltura.atlassian.net/browse/FEC-15007)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEC-15007]: https://kaltura.atlassian.net/browse/FEC-15007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ